### PR TITLE
docs: link doc site, add CONTRIBUTING and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our commitment
+
+We want VoicEra to be a welcoming, harassment-free project for everyone, regardless of experience level, background, identity, or affiliation. This applies to all project spaces — issues, pull requests, discussions, and any other official VoicEra channels — and to anyone representing the project in public spaces.
+
+## Expected behavior
+
+- Be respectful and considerate in speech and actions.
+- Welcome newcomers and help them get oriented.
+- Give and receive constructive feedback gracefully.
+- Focus criticism on the work, not the person.
+- Respect differing viewpoints and experiences.
+
+## Unacceptable behavior
+
+- Harassment, intimidation, or discrimination in any form.
+- Personal attacks, insulting or derogatory comments.
+- Publishing others' private information without consent.
+- Sustained disruption of discussions or project spaces.
+- Any other conduct that would reasonably be considered inappropriate in a professional setting.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces — for example, using an official project email address, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by emailing the maintainers privately. All reports will be reviewed and investigated, and will result in a response deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted for VoicEra and draws on common practices used across the open-source community, including the Contributor Covenant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to VoicEra
+
+Thanks for your interest in contributing. VoicEra is an open-source voice AI platform, and contributions of all sizes — bug fixes, docs, new features, translations — are welcome.
+
+This file covers the basics. For the full workflow (branching, code style, testing, PR checklist, ADRs, security guidelines), see the [Contributing guide](https://voicera.gitbook.io/voicera-docs/developer-guides/contributing) in the documentation.
+
+## Quick start
+
+1. Fork the repository and clone your fork.
+2. Follow [Local setup](https://voicera.gitbook.io/voicera-docs/developer-guides/local-setup) to get the stack running.
+3. Create a branch: `git checkout -b feat/your-feature`.
+4. Make your change, add tests, and update the relevant docs page in the same PR.
+5. Open a pull request against `main`.
+
+## Before you open a PR
+
+- Check open [issues](https://github.com/COSS-India/voicera_mono_repository/issues) for related work, and open one first for non-trivial changes.
+- Run the test suite for any service you touched.
+- No hardcoded secrets or credentials.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+
+## Reporting a security issue
+
+Do not open a public issue for a vulnerability. Email the maintainers privately with a description, reproduction steps, and impact.
+
+## Code of conduct
+
+This project follows our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A complete voice AI building block with telephony integration, featuring real-time speech-to-text, text-to-speech, and LLM-powered conversational agents.
 
+**Full documentation:** [voicera.gitbook.io/voicera-docs](https://voicera.gitbook.io/voicera-docs)
+
 ## Architecture Overview
 
 ```


### PR DESCRIPTION
## Description
Adds a link to the existing documentation site (voicera.gitbook.io/voicera-docs) directly in the README, and adds root-level CONTRIBUTING.md and CODE_OF_CONDUCT.md files. The doc site is already linked from the repository's About panel on GitHub, but not from the README content itself — so anyone reading the README directly, viewing it raw, or cloning the repo without opening the GitHub UI has no way to find it.

## Type of change
- [x] Documentation

## Changes
- README.md: added a link to the documentation site near the top
- CONTRIBUTING.md: new root-level file with quick-start contribution steps, linking to the fuller guide already in docs/guides/developer/contributing.md
- CODE_OF_CONDUCT.md: new root-level file covering expected behavior, unacceptable behavior, scope, and enforcement

## Testing
- [x] N/A — documentation-only change, no code paths affected

## Checklist
- [x] Follows the style guide
- [x] Docs updated
- [x] No new warnings