### PR TITLE
Update environment configuration and proxy settings for WebSocket con…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,5 @@ DEFAULT_ORG_CONCURRENCY_LIMIT=10
 # Comma-separated hostnames allowed as Next.js allowedDevOrigins (no scheme).
 ALLOWED_DEV_ORIGINS=voicera.johnaic.com
 
-# Browser WebSocket for live voice — public runtime host (port 7860 forward).
-NEXT_PUBLIC_RUNTIME_WS_URL=wss://vobiz.johnaic.com
+# Browser test-call WebSocket is proxied same-origin (/agent/* → runtime:7860).
+# Only port 3000 needs to be public — no separate runtime URL or ngrok on 7860.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -291,7 +291,6 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-/api/v1}"
-        NEXT_PUBLIC_RUNTIME_WS_URL: "${NEXT_PUBLIC_RUNTIME_WS_URL}"
 
     container_name: voicera_oss_frontend
     restart: unless-stopped
@@ -303,13 +302,11 @@ services:
       - .env
 
     environment:
-      # Browser calls same-origin /api/v1; Next proxies to the API service.
+      # Browser calls same-origin /api/v1 and /agent/*; Next proxies internally.
       NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-/api/v1}"
       API_PROXY_TARGET: "http://api:8000"
+      RUNTIME_PROXY_TARGET: "http://runtime:7860"
       ALLOWED_DEV_ORIGINS: "${ALLOWED_DEV_ORIGINS}"
-
-      # Browser test-call WebSocket — from root .env (NEXT_PUBLIC_RUNTIME_WS_URL).
-      NEXT_PUBLIC_RUNTIME_WS_URL: "${NEXT_PUBLIC_RUNTIME_WS_URL}"
 
     logging:
       driver: "json-file"
@@ -319,6 +316,8 @@ services:
 
     depends_on:
       api:
+        condition: service_started
+      runtime:
         condition: service_started
 
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,13 +7,12 @@ RUN npm ci
 
 COPY . .
 
-# NEXT_PUBLIC_* are inlined at build time; API_PROXY_TARGET is read at runtime in next.config.ts.
+# NEXT_PUBLIC_* are inlined at build time; proxy targets are read at runtime in next.config.ts.
 ARG NEXT_PUBLIC_API_URL=/api/v1
-ARG NEXT_PUBLIC_RUNTIME_WS_URL
 
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-ENV NEXT_PUBLIC_RUNTIME_WS_URL=$NEXT_PUBLIC_RUNTIME_WS_URL
 ENV API_PROXY_TARGET=http://api:8000
+ENV RUNTIME_PROXY_TARGET=http://runtime:7860
 
 RUN npm run build
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,12 +1,12 @@
 import type { NextConfig } from "next";
 
 /**
- * Where the Next server proxies /api/v1 → FastAPI.
- * Same machine (npm on host): http://127.0.0.1:8000
- * Docker Compose frontend service: http://api:8000
+ * Where the Next server proxies upstream services.
+ * Same machine (npm on host): API http://127.0.0.1:8000, runtime http://127.0.0.1:7860
+ * Docker Compose frontend service: API http://api:8000, runtime http://runtime:7860
  *
- * The browser always calls same-origin /api/v1, so the public hostname that
- * forwards port 3000 needs no API URL — only this internal target matters.
+ * The browser always calls same-origin /api/v1 and ws(s)://…/agent/…, so the
+ * public hostname that forwards port 3000 needs no separate API or runtime URL.
  */
 const allowedDevOrigins = (process.env.ALLOWED_DEV_ORIGINS ?? "")
   .split(",")
@@ -26,6 +26,9 @@ const nextConfig: NextConfig = {
     const apiProxyTarget = (
       process.env.API_PROXY_TARGET ?? "http://127.0.0.1:8000"
     ).replace(/\/$/, "");
+    const runtimeProxyTarget = (
+      process.env.RUNTIME_PROXY_TARGET ?? "http://127.0.0.1:7860"
+    ).replace(/\/$/, "");
     return [
       {
         source: "/api/v1/campaign/",
@@ -34,6 +37,10 @@ const nextConfig: NextConfig = {
       {
         source: "/api/v1/:path*",
         destination: `${apiProxyTarget}/api/v1/:path*`,
+      },
+      {
+        source: "/agent/:orgId/:agentId",
+        destination: `${runtimeProxyTarget}/agent/:orgId/:agentId`,
       },
     ];
   },

--- a/frontend/src/hooks/usePipecatAudio.ts
+++ b/frontend/src/hooks/usePipecatAudio.ts
@@ -61,11 +61,9 @@ export interface TranscriptMessage {
 }
 
 function getBrowserWsUrl(orgId: string, agentId: string, callId?: string): string {
-  // Get the base WebSocket URL from the environment; strip trailing slash if present.
-  // This is used to build the runtime connection URI for audio/voice agent interactions.
-  const base = (process.env.NEXT_PUBLIC_RUNTIME_WS_URL ?? "").replace(/\/$/, "");
-  // Same route as telephony — the runtime dispatches by the agent's agent_category.
-  const path = `${base}/agent/${orgId}/${agentId}`;
+  // Same-origin WebSocket — Next rewrites /agent/* → runtime:7860 (RUNTIME_PROXY_TARGET).
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const path = `${protocol}//${window.location.host}/agent/${orgId}/${agentId}`;
   return callId ? `${path}?call_id=${encodeURIComponent(callId)}` : path;
 }
 
@@ -360,6 +358,7 @@ export function usePipecatAudio(orgId: string, agentId: string) {
     }, 80);
 
     const ws = new WebSocket(getBrowserWsUrl(orgId, agentId, callId));
+    console.log("ws", ws);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
 


### PR DESCRIPTION
…nections. Remove deprecated NEXT_PUBLIC_RUNTIME_WS_URL variable and streamline WebSocket handling in the frontend. Adjust Dockerfile and next.config.ts to reflect new runtime proxy targets, ensuring consistent routing for API and agent interactions.